### PR TITLE
V4.0.0 Security improvements

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,5 +1,12 @@
 ## Release Notes
 
+### 4.0.0
+
+Breaking changes:
+
+Security header's CSP has had `unsafe-inline` removed from the `style-src`.
+Also, Https has been removed from img-src (but GA specific domains have been added).
+
 ### 3.1.1
 
 Remove link to homepage from 404 & 500 pages.

--- a/example/FamilyHubs.Example/Program.cs
+++ b/example/FamilyHubs.Example/Program.cs
@@ -9,10 +9,11 @@ builder.Services.AddFamilyHubs(builder.Configuration);
 
 var app = builder.Build();
 
+app.UseFamilyHubs();
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
-    app.UseExceptionHandler("/Error");
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }

--- a/src/FamilyHubs.SharedKernel.Razor/FamilyHubs.SharedKernel.Razor.csproj
+++ b/src/FamilyHubs.SharedKernel.Razor/FamilyHubs.SharedKernel.Razor.csproj
@@ -8,7 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 	<PackageId>FamilyHubs.SharedKernel.Razor</PackageId>
-	<VersionPrefix>3.1.1</VersionPrefix>
+	<VersionPrefix>4.0.0</VersionPrefix>
 	<PackageReadmeFile>readme.md</PackageReadmeFile>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<RepositoryUrl>https://github.com/DFE-Digital/fh-shared-kernel</RepositoryUrl>

--- a/src/FamilyHubs.SharedKernel.Razor/Pages/Shared/_Layout.cshtml
+++ b/src/FamilyHubs.SharedKernel.Razor/Pages/Shared/_Layout.cshtml
@@ -51,7 +51,7 @@
     <script src="@(familyHubsUiOptions.PathPrefix)/js/govuk-frontend-4.7.0.min.js"></script>
     <script src="@(familyHubsUiOptions.PathPrefix)/js/ministryofjustice-frontend-1.8.0.js"></script>
     <script src="@(familyHubsUiOptions.PathPrefix)/js/dfefrontend-0.1.8.js"></script>
-    <script src="@(familyHubsUiOptions.PathPrefix)/js/familyhubs-frontend-3.1.1.min.js"></script>
+    <script src="@(familyHubsUiOptions.PathPrefix)/js/familyhubs-frontend-4.0.0.min.js"></script>
     <script src="@(familyHubsUiOptions.PathPrefix)/js/app.js" asp-append-version="true"></script>
 
     <script>

--- a/src/FamilyHubs.SharedKernel.Razor/Security/SecurityHeaders.cs
+++ b/src/FamilyHubs.SharedKernel.Razor/Security/SecurityHeaders.cs
@@ -44,7 +44,6 @@ public static class SecurityHeaders
                         .Self();
 
                     builder.AddImgSrc()
-                        .OverHttps()
                         .Self();
 
                     var scriptSrc = builder.AddScriptSrc()

--- a/src/FamilyHubs.SharedKernel.Razor/Security/SecurityHeaders.cs
+++ b/src/FamilyHubs.SharedKernel.Razor/Security/SecurityHeaders.cs
@@ -30,6 +30,7 @@ public static class SecurityHeaders
                         .From(new[]
                         {
                             "https://*.google-analytics.com",
+                            "https://*.analytics.google.com",
                             //todo: is this needed in prod?
                             /* application insights*/ "https://dc.services.visualstudio.com/v2/track", "rt.services.visualstudio.com/v2/track"
                         });
@@ -44,7 +45,12 @@ public static class SecurityHeaders
                         .Self();
 
                     builder.AddImgSrc()
-                        .Self();
+                        .Self()
+                        .From(new []
+                        {
+                            "https://*.google-analytics.com",
+                            "https://*.analytics.google.com"
+                        });
 
                     var scriptSrc = builder.AddScriptSrc()
                         .Self()
@@ -59,8 +65,7 @@ public static class SecurityHeaders
 
                     builder.AddStyleSrc()
                         .Self()
-                        .StrictDynamic()
-                        .UnsafeInline();
+                        .StrictDynamic();
 
                     builder.AddMediaSrc()
                         .None();

--- a/src/familyhubs-frontend/package.json
+++ b/src/familyhubs-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "familyhubs-frontend",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "FamilyHubs Frontend contains the code you need to start building a Family Hubs website on top of the GOVUK Design System",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Breaking changes:

Security header's CSP has had `unsafe-inline` removed from the `style-src`.
Also, Https has been removed from img-src (but GA specific domains have been added).